### PR TITLE
Added third parameter (r) in '.request' callback, enabled single-call buildCurl param

### DIFF
--- a/lib/usergrid.js
+++ b/lib/usergrid.js
@@ -74,6 +74,7 @@ var AUTH_NONE = 'NONE';
     var method = options.method || 'GET';
     var endpoint = options.endpoint;
     var body = options.body || {};
+    var buildCurl = options.buildCurl || false; // buils curl output just for this request
     var qs = options.qs || {};
     var mQuery = options.mQuery || false; //is this a query to the management endpoint?
     var orgName = this.get('orgName');
@@ -112,7 +113,7 @@ var AUTH_NONE = 'NONE';
       r.body = r.body || {};
       data = data || {};
 
-      if (self.buildCurl) {
+      if (self.buildCurl || buildCurl) {
         options.uri = r.request.uri.href;
         self.buildCurlCall(options);
       }

--- a/lib/usergrid.js
+++ b/lib/usergrid.js
@@ -75,6 +75,7 @@ var AUTH_NONE = 'NONE';
     var endpoint = options.endpoint;
     var body = options.body || {};
     var buildCurl = options.buildCurl || false; // buils curl output just for this request
+    var logging = options.logging || false; // enables logging just for this request
     var qs = options.qs || {};
     var mQuery = options.mQuery || false; //is this a query to the management endpoint?
     var orgName = this.get('orgName');
@@ -98,7 +99,7 @@ var AUTH_NONE = 'NONE';
       qs['access_token'] = self.getToken();
     }
 
-    if (this.logging) {
+    if (this.logging || logging) {
       console.log('calling: ' + method + ' ' + uri);
     }
     this._start = new Date().getTime();
@@ -119,7 +120,7 @@ var AUTH_NONE = 'NONE';
       }
       self._end = new Date().getTime();
       if(r.statusCode === 200) {
-        if (self.logging) {
+        if (self.logging || logging) {
           console.log('success (time: ' + self.calcTimeDiff() + '): ' + method + ' ' + uri);
         }
         callback(err, data, r);
@@ -135,7 +136,7 @@ var AUTH_NONE = 'NONE';
           //this error type means the user is not authorized. If a logout function is defined, call it
           var error = r.body.error;
           var errorDesc = r.body.error_description;
-          if (self.logging) {
+          if (self.logging || logging) {
             console.log('Error (' + r.statusCode + ')(' + error + '): ' + errorDesc);
           }
           //if the user has specified a logout callback:
@@ -147,7 +148,7 @@ var AUTH_NONE = 'NONE';
         } else {
           var error = r.body.error;
           var errorDesc = r.body.error_description;
-          if (self.logging) {
+          if (self.logging || logging) {
             console.log('Error (' + r.statusCode + ')(' + error + '): ' + errorDesc);
           }
           if (typeof(callback) === 'function') {

--- a/lib/usergrid.js
+++ b/lib/usergrid.js
@@ -69,7 +69,7 @@ var AUTH_NONE = 'NONE';
   *  @param {function} callback
   *  @return {callback} callback(err, data)
   */
-  Usergrid.Client.prototype.request = function (options, callback) {
+  Usergrid.Client.prototype.request = function (options, callback, r) {
     var self = this;
     var method = options.method || 'GET';
     var endpoint = options.endpoint;
@@ -121,7 +121,7 @@ var AUTH_NONE = 'NONE';
         if (self.logging) {
           console.log('success (time: ' + self.calcTimeDiff() + '): ' + method + ' ' + uri);
         }
-        callback(err, data);
+        callback(err, data, r);
       } else {
         err = true;
         data.statusCode = r.statusCode;
@@ -139,9 +139,9 @@ var AUTH_NONE = 'NONE';
           }
           //if the user has specified a logout callback:
           if (typeof(self.logoutCallback) === 'function') {
-            self.logoutCallback(err, data);
+            self.logoutCallback(err, data, r);
           } else  if (typeof(callback) === 'function') {
-            callback(err, data);
+            callback(err, data, r);
           }
         } else {
           var error = r.body.error;
@@ -150,7 +150,7 @@ var AUTH_NONE = 'NONE';
             console.log('Error (' + r.statusCode + ')(' + error + '): ' + errorDesc);
           }
           if (typeof(callback) === 'function') {
-            callback(err, data);
+            callback(err, data, r);
           }
         }
       }


### PR DESCRIPTION
Enabled retrieval of raw payload (including headers, statusCode) when
using `client.request()` method. e.g.:

```
client.request(options, function(err, body, r) {
    log.debug(r.statusCode);
});
```

You can now enable curl output for a specific call via the `buildCurl:
true|false` options param. e.g.:

```
client.request({
    method: 'POST',
    endpoint: "users",
    buildCurl: true
}, function(e, body, r) {
    log.debug(body);
});
```
